### PR TITLE
Add excel export utilities

### DIFF
--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -12,25 +12,25 @@ import (
 	"os"
 
 	"errors"
-	"time"
 	"fmt"
-		"github.com/rs/zerolog"
+	"github.com/rs/zerolog"
+	"time"
 )
 
 // App struct
 type App struct {
-	ctx             context.Context
-	logger zerolog.Logger
-	itemService     *service.ItemService
-	userService     *service.UserService
-	authService     *service.AuthService
-	inboundService  *service.InboundService
-	supplierService *service.SupplierService
+	ctx              context.Context
+	logger           zerolog.Logger
+	itemService      *service.ItemService
+	userService      *service.UserService
+	authService      *service.AuthService
+	inboundService   *service.InboundService
+	supplierService  *service.SupplierService
 	warehouseService *service.WarehouseService
-	stockService    *service.StockService
-	outboundService *service.OutboundService
+	stockService     *service.StockService
+	outboundService  *service.OutboundService
 	dashboardService *service.DashboardService
-	movementService *service.MovementService
+	movementService  *service.MovementService
 }
 
 func NewApp() *App {
@@ -40,11 +40,11 @@ func NewApp() *App {
 	logFile, err := os.OpenFile("logs.txt", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	var logger zerolog.Logger
 	if err != nil {
-			logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
-			logger.Error().Err(err).Msg("Ошибка открытия файла логов, пишем в stdout")
+		logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
+		logger.Error().Err(err).Msg("Ошибка открытия файла логов, пишем в stdout")
 	} else {
-			logger = zerolog.New(logFile).With().Timestamp().Logger()
-			logger.Info().Msg("=== Приложение запущено ===")
+		logger = zerolog.New(logFile).With().Timestamp().Logger()
+		logger.Info().Msg("=== Приложение запущено ===")
 	}
 
 	itemRepo := repository.NewPgItemRepository(dbInstance, logger)
@@ -53,11 +53,11 @@ func NewApp() *App {
 	userRepo := repository.NewUserRepository(dbInstance, logger)
 	userService := service.NewUserService(userRepo, logger)
 
-	authRepo := repository.NewAuthRepository(dbInstance,logger)
+	authRepo := repository.NewAuthRepository(dbInstance, logger)
 	authService := service.NewAuthService(authRepo, logger)
 
-	inboundRepo := repository.NewInboundRepository(dbInstance,logger)
-	inboundService := service.NewInboundService(inboundRepo,itemRepo,dbInstance,logger)
+	inboundRepo := repository.NewInboundRepository(dbInstance, logger)
+	inboundService := service.NewInboundService(inboundRepo, itemRepo, dbInstance, logger)
 
 	supplierRepo := repository.NewSupplierRepository(dbInstance, logger)
 	supplierService := service.NewSupplierService(supplierRepo, dbInstance, logger)
@@ -88,19 +88,20 @@ func NewApp() *App {
 		outboundService:  outboundService,
 		dashboardService: dashboardService,
 		movementService:  movementService,
-		logger:  logger,
+		logger:           logger,
 	}
 
 }
 
 // Startup is called when the app starts
 func (a *App) Startup(ctx context.Context) {
-    a.ctx = ctx
+	a.ctx = ctx
 }
 
 func (a *App) GetDashboard() (*model.DashboardData, error) {
 	return a.dashboardService.LoadDashboard(a.ctx)
 }
+
 //-----------------------STOCKS---------------------------------\\
 
 func (a *App) GetStockDetails() ([]model.ItemWithStock, error) {
@@ -129,6 +130,21 @@ func (a *App) ExportStockToExcel() (string, error) {
 	return Export.ExportStockToExcel(a.stockService, a.logger)
 }
 
+func (a *App) ExportUsersToExcel() (string, error) {
+	return Export.ExportUsersToExcel(a.userService, a.logger)
+}
+
+func (a *App) ExportSuppliersToExcel() (string, error) {
+	return Export.ExportSuppliersToExcel(a.supplierService, a.logger)
+}
+
+func (a *App) ExportDeliveriesToExcel() (string, error) {
+	return Export.ExportDeliveriesToExcel(a.inboundService, a.logger)
+}
+
+func (a *App) ExportItemsToExcel() (string, error) {
+	return Export.ExportItemsToExcel(a.itemService, a.logger)
+}
 
 //-----------------------Items---------------------------------\\
 
@@ -144,23 +160,23 @@ func (a *App) GetTopItems() ([]model.ItemWithStock, error) {
 	return a.dashboardService.LoadTopItems(a.ctx)
 }
 
-func (a *App)  UpdateItem(item model.Item) error {
-	return a.itemService.UpdateItem(a.ctx,item)
+func (a *App) UpdateItem(item model.Item) error {
+	return a.itemService.UpdateItem(a.ctx, item)
 }
 
 func (a *App) RemoveItem(sku string) error {
-	return a.itemService.RemoveItem(a.ctx,sku)
+	return a.itemService.RemoveItem(a.ctx, sku)
 }
 
 func (a *App) AddItem(item model.Item) error {
-	return a.itemService.AddItem(a.ctx,item)
+	return a.itemService.AddItem(a.ctx, item)
 }
 
 func (a *App) FindItems(filter model.ItemFilter) ([]model.Item, error) {
-	return a.itemService.FindItems(a.ctx,filter)
+	return a.itemService.FindItems(a.ctx, filter)
 }
 
-//-----------------------Warehouse---------------------------------\\
+// -----------------------Warehouse---------------------------------\\
 func (a *App) GetWarehouses() ([]model.Warehouse, error) {
 	return a.warehouseService.GetWarehouses(a.ctx)
 }
@@ -174,30 +190,32 @@ func (a *App) EditWarehouse(warehouse model.Warehouse) error {
 func (a *App) GetTurnoverByWarehouse() ([]model.ItemTurnoverByWarehouse, error) {
 	return a.dashboardService.LoadTurnoverByWarehouse(a.ctx)
 }
+
 //-----------------------Indbound---------------------------------\\
 
-func (a *App) GetInboundDetails()([]model.InboundDetails,error){
+func (a *App) GetInboundDetails() ([]model.InboundDetails, error) {
 	return a.inboundService.ListInboundDetails(a.ctx)
 }
 
-func (a *App) GetInboundDetailsByDate(date string)([]model.InboundDetails,error){
-	return a.inboundService.ListInboundDetailsByDate(a.ctx,date)
+func (a *App) GetInboundDetailsByDate(date string) ([]model.InboundDetails, error) {
+	return a.inboundService.ListInboundDetailsByDate(a.ctx, date)
 }
 
-func (a *App) AddInbound(inb model.Inbound) error{
-	return  a.inboundService.AddInbound(a.ctx,inb);
+func (a *App) AddInbound(inb model.Inbound) error {
+	return a.inboundService.AddInbound(a.ctx, inb)
 }
-func (a *App) AddInboundTx(inb model.Inbound, item model.Item) error{
-	return  a.inboundService.AddInboundTx(a.ctx,inb,item);
+func (a *App) AddInboundTx(inb model.Inbound, item model.Item) error {
+	return a.inboundService.AddInboundTx(a.ctx, inb, item)
 }
-func (a *App) DeleteInbound(inboundId int) error{
-	return  a.inboundService.DeleteInbound(a.ctx,inboundId)
+func (a *App) DeleteInbound(inboundId int) error {
+	return a.inboundService.DeleteInbound(a.ctx, inboundId)
 }
 
-func (a *App)  EditInbound(inb model.Inbound) error{
-	return  a.inboundService.EditInbound(a.ctx,inb)
+func (a *App) EditInbound(inb model.Inbound) error {
+	return a.inboundService.EditInbound(a.ctx, inb)
 }
-//-----------------------Supplier---------------------------------\\
+
+// -----------------------Supplier---------------------------------\\
 func (a *App) GetSuppliers() ([]model.Supplier, error) {
 	return a.supplierService.GetSuppliers(a.ctx)
 }
@@ -210,27 +228,28 @@ func (a *App) AddSupplier(sp model.Supplier) error {
 func (a *App) RemoveSupplier(supplierId int) error {
 	return a.supplierService.RemoveSupplier(a.ctx, supplierId)
 }
+
 //-----------------------Auth---------------------------------\\
 
 func (a *App) RegisterUser(username, password, fullName, role string) error {
 	user := &model.User{
-			Username: username,
-			Role:     role,
-			FullName: fullName,
+		Username: username,
+		Role:     role,
+		FullName: fullName,
 	}
-	return a.authService.Register(a.ctx,user, password)
+	return a.authService.Register(a.ctx, user, password)
 }
 
 func (a *App) LoginUser(username, password string) (*model.User, error) {
-	user, ok := a.authService.Authorize(a.ctx,username, password)
+	user, ok := a.authService.Authorize(a.ctx, username, password)
 	if !ok {
-			return nil, errors.New("Неверный логин или пароль")
+		return nil, errors.New("Неверный логин или пароль")
 	}
 	return user, nil
 }
 
-func (a *App) ChangePassword(login, oldPassword, newPassword string) error{
-	return a.authService.ChangePassword(a.ctx,login,oldPassword,newPassword)
+func (a *App) ChangePassword(login, oldPassword, newPassword string) error {
+	return a.authService.ChangePassword(a.ctx, login, oldPassword, newPassword)
 }
 
 //-----------------------Users---------------------------------\\
@@ -247,9 +266,8 @@ func (a *App) ChangeUserData(u model.UserUpdate) error {
 	return a.userService.ChangeUserData(a.ctx, u)
 }
 
-
-//-----------------------Movements---------------------------------\\
-func (a *App) GetAllMovementsThisMonth() ([]model.Movement, error){
+// -----------------------Movements---------------------------------\\
+func (a *App) GetAllMovementsThisMonth() ([]model.Movement, error) {
 	return a.movementService.GetAllMovementsThisMonth(a.ctx)
 }
 

--- a/backend/internal/handler/export/inbound_report.go
+++ b/backend/internal/handler/export/inbound_report.go
@@ -1,0 +1,88 @@
+package Export
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/xuri/excelize/v2"
+	"inventory-app/backend/internal/service"
+)
+
+func ExportDeliveriesToExcel(inboundService *service.InboundService, logger zerolog.Logger) (string, error) {
+	deliveries, err := inboundService.ListInboundDetails(context.Background())
+	if err != nil {
+		logger.Error().Err(err).Msg("Ошибка при получении поставок")
+		return "", err
+	}
+
+	f := excelize.NewFile()
+	sheet := "Поставки"
+	index, _ := f.NewSheet(sheet)
+	f.SetActiveSheet(index)
+	f.DeleteSheet("Sheet1")
+
+	headers := []string{"Дата", "Наименование", "SKU", "Склад", "Поставщик", "Количество"}
+	headerStyle, _ := f.NewStyle(&excelize.Style{
+		Font:      &excelize.Font{Bold: true},
+		Fill:      excelize.Fill{Type: "pattern", Color: []string{"#D9E1F2"}, Pattern: 1},
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+	cellStyle, _ := f.NewStyle(&excelize.Style{
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+
+	f.SetColWidth(sheet, "A", "F", 22)
+
+	for col, header := range headers {
+		cell, _ := excelize.CoordinatesToCellName(col+1, 1)
+		f.SetCellValue(sheet, cell, header)
+		f.SetCellStyle(sheet, cell, cell, headerStyle)
+	}
+
+	for rowIdx, d := range deliveries {
+		values := []interface{}{d.Date, d.Name, d.Sku, d.Warehouse, d.Supplier, d.Quantity}
+		for colIdx, val := range values {
+			cell, _ := excelize.CoordinatesToCellName(colIdx+1, rowIdx+2)
+			f.SetCellValue(sheet, cell, val)
+			f.SetCellStyle(sheet, cell, cell, cellStyle)
+		}
+	}
+
+	showStripes := true
+	lastRow := len(deliveries) + 1
+	table := &excelize.Table{
+		Range:          fmt.Sprintf("A1:F%d", lastRow),
+		Name:           "DeliveriesTable",
+		StyleName:      "TableStyleMedium9",
+		ShowRowStripes: &showStripes,
+	}
+
+	if err := f.AddTable(sheet, table); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при добавлении таблицы")
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := f.Write(&buf); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при формировании файла")
+		return "", err
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	logger.Info().Int("row_count", len(deliveries)).Msg("Экспорт поставок в Excel завершён успешно")
+	return encoded, nil
+}

--- a/backend/internal/handler/export/items_report.go
+++ b/backend/internal/handler/export/items_report.go
@@ -1,0 +1,100 @@
+package Export
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/xuri/excelize/v2"
+	"inventory-app/backend/internal/service"
+)
+
+func ExportItemsToExcel(itemService *service.ItemService, logger zerolog.Logger) (string, error) {
+	items, err := itemService.ListItems(context.Background())
+	if err != nil {
+		logger.Error().Err(err).Msg("Ошибка при получении товаров")
+		return "", err
+	}
+
+	f := excelize.NewFile()
+	sheet := "Товары"
+	index, _ := f.NewSheet(sheet)
+	f.SetActiveSheet(index)
+	f.DeleteSheet("Sheet1")
+
+	headers := []string{"Наименование", "SKU", "Ед. изм.", "Описание", "Цена", "Себестоимость"}
+	headerStyle, _ := f.NewStyle(&excelize.Style{
+		Font:      &excelize.Font{Bold: true},
+		Fill:      excelize.Fill{Type: "pattern", Color: []string{"#D9E1F2"}, Pattern: 1},
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+	cellStyle, _ := f.NewStyle(&excelize.Style{
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+
+	f.SetColWidth(sheet, "A", "F", 22)
+
+	for col, header := range headers {
+		cell, _ := excelize.CoordinatesToCellName(col+1, 1)
+		f.SetCellValue(sheet, cell, header)
+		f.SetCellStyle(sheet, cell, cell, headerStyle)
+	}
+
+	for rowIdx, item := range items {
+		price := ""
+		if item.Price.Valid {
+			price = fmt.Sprintf("%.2f", item.Price.Float64)
+		}
+		cost := ""
+		if item.Cost.Valid {
+			cost = fmt.Sprintf("%.2f", item.Cost.Float64)
+		}
+		desc := ""
+		if item.Description != nil {
+			desc = *item.Description
+		}
+		values := []interface{}{item.Name, item.SKU, item.UOM, desc, price, cost}
+		for colIdx, val := range values {
+			cell, _ := excelize.CoordinatesToCellName(colIdx+1, rowIdx+2)
+			f.SetCellValue(sheet, cell, val)
+			f.SetCellStyle(sheet, cell, cell, cellStyle)
+		}
+	}
+
+	showStripes := true
+	lastRow := len(items) + 1
+	table := &excelize.Table{
+		Range:          fmt.Sprintf("A1:F%d", lastRow),
+		Name:           "ItemsTable",
+		StyleName:      "TableStyleMedium9",
+		ShowRowStripes: &showStripes,
+	}
+
+	if err := f.AddTable(sheet, table); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при добавлении таблицы")
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := f.Write(&buf); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при формировании файла")
+		return "", err
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	logger.Info().Int("row_count", len(items)).Msg("Экспорт товаров в Excel завершён успешно")
+	return encoded, nil
+}

--- a/backend/internal/handler/export/suppliers_report.go
+++ b/backend/internal/handler/export/suppliers_report.go
@@ -1,0 +1,104 @@
+package Export
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/xuri/excelize/v2"
+	"inventory-app/backend/internal/service"
+)
+
+func ExportSuppliersToExcel(supplierService *service.SupplierService, logger zerolog.Logger) (string, error) {
+	suppliers, err := supplierService.GetSuppliers(context.Background())
+	if err != nil {
+		logger.Error().Err(err).Msg("Ошибка при получении поставщиков")
+		return "", err
+	}
+
+	f := excelize.NewFile()
+	sheet := "Поставщики"
+	index, _ := f.NewSheet(sheet)
+	f.SetActiveSheet(index)
+	f.DeleteSheet("Sheet1")
+
+	headers := []string{"Название", "ИНН", "Контактное лицо", "Телефон", "Email"}
+	headerStyle, _ := f.NewStyle(&excelize.Style{
+		Font:      &excelize.Font{Bold: true},
+		Fill:      excelize.Fill{Type: "pattern", Color: []string{"#D9E1F2"}, Pattern: 1},
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+	cellStyle, _ := f.NewStyle(&excelize.Style{
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+
+	f.SetColWidth(sheet, "A", "E", 22)
+
+	for col, header := range headers {
+		cell, _ := excelize.CoordinatesToCellName(col+1, 1)
+		f.SetCellValue(sheet, cell, header)
+		f.SetCellStyle(sheet, cell, cell, headerStyle)
+	}
+
+	for rowIdx, s := range suppliers {
+		inn := ""
+		if s.Inn != nil {
+			inn = *s.Inn
+		}
+		contact := ""
+		if s.ContactPerson != nil {
+			contact = *s.ContactPerson
+		}
+		phone := ""
+		if s.Phone != nil {
+			phone = *s.Phone
+		}
+		email := ""
+		if s.Email != nil {
+			email = *s.Email
+		}
+		values := []interface{}{s.Name, inn, contact, phone, email}
+		for colIdx, val := range values {
+			cell, _ := excelize.CoordinatesToCellName(colIdx+1, rowIdx+2)
+			f.SetCellValue(sheet, cell, val)
+			f.SetCellStyle(sheet, cell, cell, cellStyle)
+		}
+	}
+
+	showStripes := true
+	lastRow := len(suppliers) + 1
+	table := &excelize.Table{
+		Range:          fmt.Sprintf("A1:E%d", lastRow),
+		Name:           "SuppliersTable",
+		StyleName:      "TableStyleMedium9",
+		ShowRowStripes: &showStripes,
+	}
+
+	if err := f.AddTable(sheet, table); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при добавлении таблицы")
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := f.Write(&buf); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при формировании файла")
+		return "", err
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	logger.Info().Int("row_count", len(suppliers)).Msg("Экспорт поставщиков в Excel завершён успешно")
+	return encoded, nil
+}

--- a/backend/internal/handler/export/users_report.go
+++ b/backend/internal/handler/export/users_report.go
@@ -1,0 +1,88 @@
+package Export
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/xuri/excelize/v2"
+	"inventory-app/backend/internal/service"
+)
+
+func ExportUsersToExcel(userService *service.UserService, logger zerolog.Logger) (string, error) {
+	users, err := userService.GetUsers(context.Background())
+	if err != nil {
+		logger.Error().Err(err).Msg("Ошибка при получении пользователей")
+		return "", err
+	}
+
+	f := excelize.NewFile()
+	sheet := "Пользователи"
+	index, _ := f.NewSheet(sheet)
+	f.SetActiveSheet(index)
+	f.DeleteSheet("Sheet1")
+
+	headers := []string{"ID", "Логин", "ФИО", "Роль"}
+	headerStyle, _ := f.NewStyle(&excelize.Style{
+		Font:      &excelize.Font{Bold: true},
+		Fill:      excelize.Fill{Type: "pattern", Color: []string{"#D9E1F2"}, Pattern: 1},
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+	cellStyle, _ := f.NewStyle(&excelize.Style{
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "000000", Style: 1},
+			{Type: "top", Color: "000000", Style: 1},
+			{Type: "bottom", Color: "000000", Style: 1},
+			{Type: "right", Color: "000000", Style: 1},
+		},
+	})
+
+	f.SetColWidth(sheet, "A", "D", 22)
+
+	for col, header := range headers {
+		cell, _ := excelize.CoordinatesToCellName(col+1, 1)
+		f.SetCellValue(sheet, cell, header)
+		f.SetCellStyle(sheet, cell, cell, headerStyle)
+	}
+
+	for rowIdx, u := range users {
+		values := []interface{}{u.UserID, u.Username, u.FullName, u.Role}
+		for colIdx, val := range values {
+			cell, _ := excelize.CoordinatesToCellName(colIdx+1, rowIdx+2)
+			f.SetCellValue(sheet, cell, val)
+			f.SetCellStyle(sheet, cell, cell, cellStyle)
+		}
+	}
+
+	showStripes := true
+	lastRow := len(users) + 1
+	table := &excelize.Table{
+		Range:          fmt.Sprintf("A1:D%d", lastRow),
+		Name:           "UsersTable",
+		StyleName:      "TableStyleMedium9",
+		ShowRowStripes: &showStripes,
+	}
+
+	if err := f.AddTable(sheet, table); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при добавлении таблицы")
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := f.Write(&buf); err != nil {
+		logger.Error().Err(err).Msg("Ошибка при формировании файла")
+		return "", err
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	logger.Info().Int("row_count", len(users)).Msg("Экспорт пользователей в Excel завершён успешно")
+	return encoded, nil
+}

--- a/frontend/dist/wailsjs/go/app/App.d.ts
+++ b/frontend/dist/wailsjs/go/app/App.d.ts
@@ -34,6 +34,14 @@ export function EditWarehouse(arg1:model.Warehouse):Promise<void>;
 
 export function ExportStockToExcel():Promise<string>;
 
+export function ExportUsersToExcel():Promise<string>;
+
+export function ExportSuppliersToExcel():Promise<string>;
+
+export function ExportDeliveriesToExcel():Promise<string>;
+
+export function ExportItemsToExcel():Promise<string>;
+
 export function FindItems(arg1:model.ItemFilter):Promise<Array<model.Item>>;
 
 export function FindStockByWarehouse(arg1:number):Promise<Array<model.ItemWithStock>>;

--- a/frontend/dist/wailsjs/go/app/App.js
+++ b/frontend/dist/wailsjs/go/app/App.js
@@ -66,6 +66,22 @@ export function ExportStockToExcel() {
   return window['go']['app']['App']['ExportStockToExcel']();
 }
 
+export function ExportUsersToExcel() {
+  return window['go']['app']['App']['ExportUsersToExcel']();
+}
+
+export function ExportSuppliersToExcel() {
+  return window['go']['app']['App']['ExportSuppliersToExcel']();
+}
+
+export function ExportDeliveriesToExcel() {
+  return window['go']['app']['App']['ExportDeliveriesToExcel']();
+}
+
+export function ExportItemsToExcel() {
+  return window['go']['app']['App']['ExportItemsToExcel']();
+}
+
 export function FindItems(arg1) {
   return window['go']['app']['App']['FindItems'](arg1);
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1135,6 +1135,7 @@ import { ChangeStock } from '../wailsjs/go/app/App'
 import { GetStockDetails } from '../wailsjs/go/app/App'
 import { RemoveStock } from '../wailsjs/go/app/App'
 import { ExportStockToExcel } from '../wailsjs/go/app/App'
+import { ExportUsersToExcel, ExportSuppliersToExcel, ExportDeliveriesToExcel, ExportItemsToExcel } from '../wailsjs/go/app/App'
 import LoginForm from './components/LoginForm.vue'
 import {
   GetOutboundDetails, AddOutbound, EditOutbound, RemoveOutbound
@@ -1381,7 +1382,22 @@ async function deleteUser(u) {
 }
 
 function exportUsersToExcel() {
-  alert('Заглушка экспорта пользователей')
+  ExportUsersToExcel().then(base64data => {
+    const binary = atob(base64data)
+    const len = binary.length
+    const bytes = new Uint8Array(len)
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    const blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(blob)
+    link.download = 'users.xlsx'
+    link.click()
+    setTimeout(() => URL.revokeObjectURL(link.href), 1000)
+  }).catch(err => {
+    alert('Ошибка экспорта: ' + err)
+  })
 }
 
 function handleLogin() {
@@ -1583,7 +1599,22 @@ function maskPhone(event, obj) {
 
 
 function exportSuppliersToExcel() {
-  alert('Заглушка экспорта поставщиков')
+  ExportSuppliersToExcel().then(base64data => {
+    const binary = atob(base64data)
+    const len = binary.length
+    const bytes = new Uint8Array(len)
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    const blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(blob)
+    link.download = 'suppliers.xlsx'
+    link.click()
+    setTimeout(() => URL.revokeObjectURL(link.href), 1000)
+  }).catch(err => {
+    alert('Ошибка экспорта: ' + err)
+  })
 }
 
 function exportToExcel() {
@@ -1972,7 +2003,22 @@ function deleteDelivery(delivery) {
 }
 
 function exportDeliveriesToExcel() {
-  alert('Заглушка экспорта. Тут будет экспорт в Excel')
+  ExportDeliveriesToExcel().then(base64data => {
+    const binary = atob(base64data)
+    const len = binary.length
+    const bytes = new Uint8Array(len)
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    const blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(blob)
+    link.download = 'deliveries.xlsx'
+    link.click()
+    setTimeout(() => URL.revokeObjectURL(link.href), 1000)
+  }).catch(err => {
+    alert('Ошибка экспорта: ' + err)
+  })
 }
 
 // Форматирование даты, чтобы не падало
@@ -2137,7 +2183,22 @@ const totalStockPerItem = computed(() => {
 })
 
 function exportItemsToExcel() {
-  alert('Заглушка экспорта товаров в Excel');
+  ExportItemsToExcel().then(base64data => {
+    const binary = atob(base64data)
+    const len = binary.length
+    const bytes = new Uint8Array(len)
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    const blob = new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(blob)
+    link.download = 'items.xlsx'
+    link.click()
+    setTimeout(() => URL.revokeObjectURL(link.href), 1000)
+  }).catch(err => {
+    alert('Ошибка экспорта: ' + err)
+  })
 }
 function closeAddModal() {
   showAddModal.value = false


### PR DESCRIPTION
## Summary
- implement Excel export handlers for items, suppliers, deliveries and users
- expose export methods via backend App
- expose new functions to frontend bridge
- implement export buttons in the UI

## Testing
- `go vet ./...`
- `npm run build` *(fails: vite command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624a03a7ac832c8f5c1f449fab3b31